### PR TITLE
Add variable support in stub names

### DIFF
--- a/config/stubkit.php
+++ b/config/stubkit.php
@@ -196,5 +196,8 @@ return [
    | These settings refer to the make:views command.
    |--------------------------------------------------------------------------
    */
-    'view_path' => 'views/{{model.slugPlural}}/{{view.slug}}.blade.php',
+    'views' => [
+        'path' => 'resources/views/{{model.slugPlural}}/{{view.slug}}.blade.php',
+        'stubs' => ['index', 'create', 'show', 'edit']
+    ],
 ];

--- a/src/Commands/ViewsMakeCommand.php
+++ b/src/Commands/ViewsMakeCommand.php
@@ -39,9 +39,7 @@ class ViewsMakeCommand extends Command
     {
         parent::__construct();
 
-        $this->views = config('stubkit.views', [
-            'index', 'create', 'show', 'edit',
-        ]);
+        $this->views = config('stubkit.views.stubs', []);
     }
 
     /**
@@ -88,20 +86,17 @@ class ViewsMakeCommand extends Command
      */
     public function makeView(string $view)
     {
-//        $path = config('stubkit.views.path', 'js/Pages/{{model.studlyPlural}}/{{view.studly}}.vue');
-        $path = config('stubkit.view_path');
-
-        $values = [
-            'view' => $view,
-            'model' => Str::reset($this->argument('name'))
-        ];
-
         $syntax = (new Syntax())->make(
-            $values,
+            ['model' => Str::reset($this->argument('name'))],
             config('stubkit.variables.*', [])
         );
 
-        $path = $syntax->parse($path);
+        $syntax->make(
+            ['view' => $syntax->parse($view)],
+            config('stubkit.variables.*', [])
+        );
+
+        $path = $syntax->parse(config('stubkit.views.path'));
 
         if (file_exists(base_path("stubs/view.${view}.stub"))) {
             $stub = base_path("stubs/view.${view}.stub");
@@ -111,7 +106,7 @@ class ViewsMakeCommand extends Command
             $stub = false;
         }
 
-        $path = resource_path($path);
+        $path = base_path($path);
 
         $content = ($stub) ? file_get_contents($stub) : '';
 

--- a/tests/MakeViewsTest.php
+++ b/tests/MakeViewsTest.php
@@ -57,4 +57,16 @@ class MakeViewsTest extends TestCase
             ->expectsOutput('Views already exists!')
             ->assertExitCode(1);
     }
+
+    public function test_view_path_using_variables()
+    {
+        config()->set('stubkit.views.stubs', ['create-{{model.studly}}-form']);
+        config()->set('stubkit.views.path', 'resources/js/Pages/{{model.studlyPlural}}/{{view.studly}}.vue');
+
+        mkdir(__DIR__.'/Fixtures/app/stubs');
+        file_put_contents(__DIR__.'/Fixtures/app/stubs/view.create-{{model.studly}}-form.stub', '');
+        $this->artisan('make:views User');
+
+        $this->assertFileExists(base_path('resources/js/Pages/Users/CreateUserForm.vue'));
+    }
 }


### PR DESCRIPTION
This PR allows views like `resources/js/Pages/Users/CreateUsersForm.vue` like jetstream uses.

This is a continuation of #1