### PR TITLE
Add syntax get method

### DIFF
--- a/tests/SyntaxTest.php
+++ b/tests/SyntaxTest.php
@@ -146,4 +146,22 @@ class SyntaxTest extends TestCase
         $output = $syntax->parse(' {{ model.studly }} ');
         $this->assertEquals(' User ', $output);
     }
+
+    public function test_getting_single_variable()
+    {
+        $variables = [
+            'url' => 'google.com',
+            'user' => [
+                'upper' => function ($value) {
+                    return ucfirst($value);
+                },
+            ]
+        ];
+
+        $syntax = (new Syntax())->make(['user' => 'sara'], [], $variables);
+
+        $this->assertEquals('google.com', $syntax->get('url'));
+        $this->assertEquals('Sara', $syntax->get('user.upper'));
+        $this->assertEquals(null, $syntax->get('missing'));
+    }
 }


### PR DESCRIPTION
Allows getting a single variable:
```php
StubKit::syntax()->get('model.titlePlural')
```