### PR TITLE
Add basic js field formats

### DIFF
--- a/views/formats/array.blade.php
+++ b/views/formats/array.blade.php
@@ -1,0 +1,14 @@
+@php
+
+$output = '';
+
+$fields = explode(',', $fields);
+
+foreach($fields as $field) {
+    $output .= "'" . trim($field) . "',";
+}
+
+$output = '['. rtrim($output, ',') .']';
+
+@endphp
+{!! $output !!}

--- a/views/formats/js-object-empty.blade.php
+++ b/views/formats/js-object-empty.blade.php
@@ -1,0 +1,14 @@
+@php
+
+use StubKit\Support\Fields;
+
+$output = '';
+
+foreach ((new Fields(config('stubkit-types'), config('stubkit-mappings')))->str($fields) as $field) {
+    $output .= "'{$field->snake()}': '',\n";
+}
+
+$output = rtrim($output);
+
+@endphp
+{!! $output !!}

--- a/views/formats/js-object-filled.blade.php
+++ b/views/formats/js-object-filled.blade.php
@@ -1,0 +1,17 @@
+@php
+
+use StubKit\Facades\StubKit;
+use StubKit\Support\Fields;
+
+$output = '';
+
+$model = StubKit::syntax()->get('model.snake');
+
+foreach ((new Fields(config('stubkit-types'), config('stubkit-mappings')))->str($fields) as $field) {
+    $output .= "'{$field->snake()}': this.$model.{$field->snake()},\n";
+}
+
+$output = rtrim($output);
+
+@endphp
+{!! $output !!}


### PR DESCRIPTION
Adds a `/resources/vendors/stubkit/formats` as a good place to add custom formats.

Adds 3 example usecases that jetty will use by default that others may also want to.

Will improve code in housecleaning PR, just need this for other work in progress